### PR TITLE
Fix solid:Registration typo

### DIFF
--- a/src/preferences.js
+++ b/src/preferences.js
@@ -73,7 +73,7 @@ function recordPersonalDefaults (klass, context) {
         }
       } else { // no regs fo class
         reg = widgets.newThing(context.preferencesFile)
-        ins = [ $rdf.st(reg, ns.rdf('type'), ns.solid('Regsitration'), context.preferencesFile),
+        ins = [ $rdf.st(reg, ns.rdf('type'), ns.solid('Registration'), context.preferencesFile),
           $rdf.st(reg, ns.solid('forClass'), klass, context.preferencesFile)]
       }
       prefs = widgets.newThing(context.preferencesFile)


### PR DESCRIPTION
When writing a preferences file, `solid:Registration` would be misspelled.

I'm using a PR for this trivial fix in case other systems would rely on this typo.