### PR TITLE
Use default popup URI

### DIFF
--- a/src/signin.js
+++ b/src/signin.js
@@ -736,7 +736,7 @@ function signInOrSignUpBox (dom, setUserCallback) {
   signInPopUpButton.addEventListener('click', () => {
     var offline = offlineTestID()
     if (offline) return setUserCallback(offline.uri)
-    return solidAuthClient.popupLogin({ popupUri: $SOLID_GLOBAL_config.popupUri })
+    return solidAuthClient.popupLogin()
       .then(session => {
         let webIdURI = session.webId
         // setUserCallback(webIdURI)


### PR DESCRIPTION
solid-auth-client supports a .well-known popup URI as a default, so it is not necessary to specify this popup.

Moreover, if we do specify this popup URI, we risk running into https://github.com/solid/solid-auth-client/issues/54

Also, with the current implementation, Mashlib crashes if `$SOLID_GLOBAL_config` is not set.