### PR TITLE
Pass the store when creating a new pane

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -72,7 +72,7 @@ function newThingUI (context, thePanes) {
             newPaneOptions[opt] = options[opt]
           }
           console.log('newThingUI: Minting new ' + newPaneOptions.pane.name + ' at ' + newPaneOptions.newBase)
-          options.pane.mintNew(newPaneOptions)
+          options.pane.mintNew(newPaneOptions, UI.store)
             .then(function (newPaneOptions) {
               if (!newPaneOptions || !newPaneOptions.newInstance) {
                 throw new Error('Cannot mint new - missing newInstance')


### PR DESCRIPTION
When panes are loaded dynamically and thus are in their own Node module with their own scope, they do not have access to the global `UI` object, and therefore also cannot access the store. Thus, we should pass the store to the `mintNew` function when it is provided by a dynamically-loaded pane.

(@megoth It appears I also don't have rights to this repository yet.)