### PR TITLE
Ignoring JetBrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 lib
+.idea


### PR DESCRIPTION
Just a small fix to make setup a bit easier for users of JetBrains IDEs (myself included). Tried adding [suggestiono of .gitignore from gitignore.io](https://www.gitignore.io/api/osx,node,code,windows,jetbrains), which leaves some .idea-files to be inserted, but concluded that's probably just going to be annoying for non-JetBrains developers.