### PR TITLE
Need to set an empty string as last value possible

### DIFF
--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -913,7 +913,7 @@ UI.widgets.field[UI.ns.ui('PhoneField').uri] =
                             field.value = decodeURIComponent(obj.uri.replace(params.uriPrefix, '')) // should have no spaces but in case
                               .replace(/ /g, '')
                           } else if (obj) {
-                            field.value = obj.value || obj.uri
+                            field.value = obj.value || obj.uri || ''
                           }
                           field.setAttribute('style', style)
                           field.addEventListener('keyup', function (e) {


### PR DESCRIPTION
obj.uri might be undefined, which will output "undefined" in field values since empty string are falsish

This should fix https://github.com/solid/solid-panes/issues/118