### PR TITLE
Changing from defaultForNew to default with fallback

### DIFF
--- a/src/acl-control.js
+++ b/src/acl-control.js
@@ -545,6 +545,7 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
         box.isContainer = targetDoc.uri.slice(-1) === '/' // Give default for all directories
         if (defa) {
           var defaults = kb.each(undefined, ACL('defaultForNew'), defaultHolder, defaultACLDoc)
+            .concat(kb.each(undefined, ACL('default'), defaultHolder, defaultACLDoc))
           if (!defaults.length) {
             statusBlock.textContent += ' (No defaults given.)'
           } else {

--- a/src/signin.js
+++ b/src/signin.js
@@ -776,7 +776,7 @@ function genACLText (docURI, me, aclURI, options = {}) {
   g.add(a, UI.ns.rdf('type'), auth('Authorization'), acl)
   g.add(a, auth('accessTo'), doc, acl)
   if (options.defaultForNew) {
-    g.add(a, auth('defaultForNew'), doc, acl)
+    g.add(a, auth('default'), doc, acl)
   }
   g.add(a, auth('agent'), me, acl)
   g.add(a, auth('mode'), auth('Read'), acl)


### PR DESCRIPTION
The fallback strategy is to query for `acl:defaultForNew` (in addition to `acl:default`), to handle resources that uses the obsolete property.

Making sure to use `acl:default` for new resources.

This fixes https://github.com/solid/solid-ui/issues/76