### PR TITLE
Only adding a slash to destUri if folderName does not already have it

### DIFF
--- a/src/widgets/dragAndDrop.js
+++ b/src/widgets/dragAndDrop.js
@@ -195,7 +195,7 @@ function uploadFiles (fetcher, files, fileBase, imageBase, successHandler) {
           }
         }
         var folderName = theFile.type.startsWith('image/') ? imageBase || fileBase : fileBase
-        var destURI = folderName + '/' + encodeURIComponent(theFile.name) + suffix
+        var destURI = folderName + (folderName.endsWith('/') ? '' : '/') + encodeURIComponent(theFile.name) + suffix
 
         fetcher.webOperation('PUT', destURI, { data: data, contentType: contentType })
           .then(response => {


### PR DESCRIPTION
The handling of ACL for root failed because the URI to PUT the file to contained an extra slash (e.g. `https://test.com//foo.txt` instead of `https://test.com/foo.txt`). This was an error that also happens when trying to upload files elsewhere, but it was allowed then.

This should fix https://github.com/solid/solid-panes/issues/143