### PR TITLE
Do not prefill a value for a checkbox

### DIFF
--- a/src/widgets/forms.js
+++ b/src/widgets/forms.js
@@ -1202,20 +1202,22 @@ function buildCheckboxForm (dom, kb, lab, del, ins, form, store, tristate) { // 
   }
   function refresh () {
     var state = holdsAll(ins)
+    var displayState = state
     if (del.length) {
       var negation = holdsAll(del)
       if (state && negation) {
-        box.appendChild(error.errorMessageBlock(dom,
+        box.appendChild(UI.widgets.errorMessageBlock(dom,
           'Inconsistent data in store!\n' + ins + ' and\n' + del))
         return box
       }
       if (!state && !negation) {
+        state = null
         let defa = kb.any(form, UI.ns.ui('default'))
-        state = defa ? defa.value === '1' : tristate ? null : false
+        displayState = defa ? defa.value === '1' : tristate ? null : false
       }
     }
     input.state = state
-    input.textContent = {true: checkMarkCharacter, false: cancelCharacter, null: dashCharacter}[input.state]
+    input.textContent = {true: checkMarkCharacter, false: cancelCharacter, null: dashCharacter}[displayState]
   }
 
   refresh()


### PR DESCRIPTION
If the BooleanField in the given resource is not set, the tristate
logic would set it to false by default. This commit changes that to
differentiate between the value that is shown (false), and the
value that's actually present on the web.

These changes were made as per Tim's instructions. They came up when working on https://github.com/solid/solid-panes/issues/144.