### PR TITLE
Prevent users from deleting their root ACLs

### DIFF
--- a/src/acl-control.js
+++ b/src/acl-control.js
@@ -612,14 +612,17 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
           var q = str.indexOf('//')
           var targetDocDir = ((q >= 0 && p < q + 2) || p < 0) ? null : str.slice(0, p + 1)
 
-          if (targetDocDir) {
+          // eslint-disable-next-line no-undef
+          const targetIsStorage = kb.holds(targetDoc, UI.ns.rdf('type'), UI.ns.space('Storage'), targetACLDoc) || (location && location.pathname === '/')
+
+          if (!targetIsStorage && targetDocDir) {
             UI.acl.getACLorDefault($rdf.sym(targetDocDir), function (ok2, p22, targetDoc2, targetACLDoc2, defaultHolder2, defaultACLDoc2) {
               if (ok2) {
                 prospectiveDefaultHolder = p22 ? targetDoc2 : defaultHolder2
               }
               addDefaultButton(prospectiveDefaultHolder)
             })
-          } else {
+          } else if (!targetIsStorage) {
             addDefaultButton()
           }
 

--- a/src/acl-control.js
+++ b/src/acl-control.js
@@ -612,6 +612,8 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
           var q = str.indexOf('//')
           var targetDocDir = ((q >= 0 && p < q + 2) || p < 0) ? null : str.slice(0, p + 1)
 
+          // @@ TODO: The methods used for targetIsStorage are HACKs - it should not be relied upon, and work is
+          // @@ underway to standardize a behavior that does not rely upon this hack
           // eslint-disable-next-line no-undef
           const targetIsStorage = kb.holds(targetDoc, UI.ns.rdf('type'), UI.ns.space('Storage'), targetACLDoc) || (location && location.pathname === '/')
 

--- a/src/acl-control.js
+++ b/src/acl-control.js
@@ -615,17 +615,18 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
           // @@ TODO: The methods used for targetIsStorage are HACKs - it should not be relied upon, and work is
           // @@ underway to standardize a behavior that does not rely upon this hack
           // @@ hopefully fixed as part of https://github.com/solid/data-interoperability-panel/issues/10
-          const targetIsStorage = kb.holds(targetDoc, UI.ns.rdf('type'), UI.ns.space('Storage'), targetACLDoc) ||
-            (window.location && window.location.pathname === '/')
+          const targetIsStorage = kb.holds(targetDoc, UI.ns.rdf('type'), UI.ns.space('Storage'), targetACLDoc)
+          const targetAclIsProtected = hasProtectedAcl(targetDoc)
+          const targetIsProtected = targetIsStorage || targetAclIsProtected
 
-          if (!targetIsStorage && targetDocDir) {
+          if (!targetIsProtected && targetDocDir) {
             UI.acl.getACLorDefault($rdf.sym(targetDocDir), function (ok2, p22, targetDoc2, targetACLDoc2, defaultHolder2, defaultACLDoc2) {
               if (ok2) {
                 prospectiveDefaultHolder = p22 ? targetDoc2 : defaultHolder2
               }
               addDefaultButton(prospectiveDefaultHolder)
             })
-          } else if (!targetIsStorage) {
+          } else if (!targetIsProtected) {
             addDefaultButton()
           }
 
@@ -691,4 +692,10 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
   renderBox()
   return table
 } // ACLControlBox
+
+function hasProtectedAcl (targetDoc) {
+  // @@ TODO: This is hacky way of knowing whether or not a certain ACL file can be removed
+  // Hopefully we'll find a better, standardized solution to this - https://github.com/solid/specification/issues/37
+  return targetDoc.uri === targetDoc.site().uri
+}
 // ends

--- a/src/acl-control.js
+++ b/src/acl-control.js
@@ -614,8 +614,9 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
 
           // @@ TODO: The methods used for targetIsStorage are HACKs - it should not be relied upon, and work is
           // @@ underway to standardize a behavior that does not rely upon this hack
-          // eslint-disable-next-line no-undef
-          const targetIsStorage = kb.holds(targetDoc, UI.ns.rdf('type'), UI.ns.space('Storage'), targetACLDoc) || (location && location.pathname === '/')
+          // @@ hopefully fixed as part of https://github.com/solid/data-interoperability-panel/issues/10
+          const targetIsStorage = kb.holds(targetDoc, UI.ns.rdf('type'), UI.ns.space('Storage'), targetACLDoc) ||
+            (window.location && window.location.pathname === '/')
 
           if (!targetIsStorage && targetDocDir) {
             UI.acl.getACLorDefault($rdf.sym(targetDocDir), function (ok2, p22, targetDoc2, targetACLDoc2, defaultHolder2, defaultACLDoc2) {


### PR DESCRIPTION
This checks whether pathname indicates that the target is root, or whether the root ACL itself states that the target is root.

Going to create a PR for NSS as well that adds `<.> a sp:Storage.` as default for all _new_ root ACLs.