### PR TITLE
Restore undefined newThing

### DIFF
--- a/src/widgets/forms.js
+++ b/src/widgets/forms.js
@@ -23,6 +23,14 @@ const checkMarkCharacter = '\u2713'
 const cancelCharacter = '\u2715'
 const dashCharacter = '-'
 
+/** Mint local ID using timestamp
+ * @param {NamedNode} doc - the document in which the ID is to be generated
+ */
+forms.newThing = function (doc) {
+  var now = new Date()
+  return $rdf.sym(doc.uri + '#' + 'id' + ('' + now.getTime()))
+}
+
 // ///////////////////////////////////////////////////////////////////////
 
 /*                                  Form Field implementations


### PR DESCRIPTION
Note that it is also present in `buttons`, but since it was just
two lines and does not appear to be related specifically to
buttons, I went with just duplicating the code for forms.

It was broken initially by f618510e95d139fceeb0bbda9e85c50239160090, in which `newThing` was
moved to buttons but not to forms.

Fixes #106.

(Basically the same reason b7589cd394751c126718b360e5a1eeb9a46bfcbd was needed.)