### PR TITLE
Allow for creation of ACL resources on folders directly under root

### DIFF
--- a/src/acl.js
+++ b/src/acl.js
@@ -337,7 +337,7 @@ UI.acl.getACLorDefault = function (doc, callbackFunction) {
       }
       var right = uri.lastIndexOf('/')
       var left = uri.indexOf('/', uri.indexOf('//') + 2)
-      if (left >= right) {
+      if (left > right) {
         return callbackFunction(false, true, 404, 'Found no ACL resource')
       }
       uri = uri.slice(0, right + 1)


### PR DESCRIPTION
This fixes https://github.com/solid/solid-ui/issues/99

The test was there to prohibit calls on https://, as we had a recursive call that would do that. But this also prohibits call that would check for the root ACLs, so need to make it a bit less strict.