### PR TITLE
Extracted findProfileImage from findImage in setImage

### DIFF
--- a/src/signin.js
+++ b/src/signin.js
@@ -37,7 +37,6 @@ module.exports = {
   filterAvailablePanes, // Async
   findAppInstances,
   findOriginOwner,
-  findProfileImage, // Sync
   getUserRoles, // Async
   loadTypeIndexes,
   logIn,
@@ -1304,19 +1303,6 @@ async function getUserRoles () {
   return UI.store.each(profile, ns.rdf('type'), null, preferencesFile.doc())
 }
 
-function findProfileImage (profile) {
-  const iconDir = UI.icons.iconBase
-  if (profile.sameTerm(ns.foaf('Agent')) || profile.sameTerm(ns.rdf('Resource'))) {
-    return iconDir + 'noun_98053.svg' // Globe
-  }
-  const image = kb.any(profile, ns.sioc('avatar')) ||
-    kb.any(profile, ns.foaf('img')) ||
-    kb.any(profile, ns.vcard('logo')) ||
-    kb.any(profile, ns.vcard('hasPhoto')) ||
-    kb.any(profile, ns.vcard('photo')) ||
-    kb.any(profile, ns.foaf('depiction'))
-  return image ? image.uri : null
-}
 async function filterAvailablePanes (panes) {
   const userRoles = await getUserRoles()
   return Object.values(panes).filter(pane => isMatchingAudience(pane, userRoles))

--- a/src/signin.js
+++ b/src/signin.js
@@ -37,6 +37,7 @@ module.exports = {
   filterAvailablePanes, // Async
   findAppInstances,
   findOriginOwner,
+  findProfileImage, // Sync
   getUserRoles, // Async
   loadTypeIndexes,
   logIn,
@@ -1303,6 +1304,19 @@ async function getUserRoles () {
   return UI.store.each(profile, ns.rdf('type'), null, preferencesFile.doc())
 }
 
+function findProfileImage (profile) {
+  const iconDir = UI.icons.iconBase
+  if (profile.sameTerm(ns.foaf('Agent')) || profile.sameTerm(ns.rdf('Resource'))) {
+    return iconDir + 'noun_98053.svg' // Globe
+  }
+  const image = kb.any(profile, ns.sioc('avatar')) ||
+    kb.any(profile, ns.foaf('img')) ||
+    kb.any(profile, ns.vcard('logo')) ||
+    kb.any(profile, ns.vcard('hasPhoto')) ||
+    kb.any(profile, ns.vcard('photo')) ||
+    kb.any(profile, ns.foaf('depiction'))
+  return image ? image.uri : null
+}
 async function filterAvailablePanes (panes) {
   const userRoles = await getUserRoles()
   return Object.values(panes).filter(pane => isMatchingAudience(pane, userRoles))

--- a/src/widgets/buttons.js
+++ b/src/widgets/buttons.js
@@ -2,6 +2,8 @@
 */
 /* global alert */
 
+const { findProfileImage } = require('../signin')
+
 module.exports = {}
 
 var buttons = {}
@@ -221,28 +223,13 @@ buttons.findImageByClass = function findImageByClass (x) {
 
 // @@ Also add icons for *properties* like  home, work, email, range, domain, comment,
 
-buttons.setImage = function (element, x) {
+buttons.setImage = function (element, profile) {
   const kb = UI.store
-  const ns = UI.ns
-  const iconDir = UI.icons.iconBase
-  var findImage = function (x) {
-    if (x.sameTerm(ns.foaf('Agent')) || x.sameTerm(ns.rdf('Resource'))) {
-      return iconDir + 'noun_98053.svg' // Globe
-    }
-    var image = kb.any(x, ns.sioc('avatar')) ||
-      kb.any(x, ns.foaf('img')) ||
-      kb.any(x, ns.vcard('logo')) ||
-      kb.any(x, ns.vcard('hasPhoto')) ||
-      kb.any(x, ns.vcard('photo')) ||
-      kb.any(x, ns.foaf('depiction'))
-    return image ? image.uri : null
-  }
-
-  var uri = findImage(x)
-  element.setAttribute('src', uri || buttons.findImageByClass(x))
-  if (!uri && x.uri) {
-    kb.fetcher.nowOrWhenFetched(x.doc(), undefined, function (ok) {
-      element.setAttribute('src', findImage(x) || buttons.findImageByClass(x))
+  const uri = findProfileImage(profile)
+  element.setAttribute('src', uri || buttons.findImageByClass(profile))
+  if (!uri && profile.uri) {
+    kb.fetcher.nowOrWhenFetched(profile.doc(), undefined, () => {
+      element.setAttribute('src', findProfileImage(profile) || buttons.findImageByClass(profile))
     })
   }
 }

--- a/src/widgets/buttons.js
+++ b/src/widgets/buttons.js
@@ -2,8 +2,6 @@
 */
 /* global alert */
 
-const { findProfileImage } = require('../signin')
-
 module.exports = {}
 
 var buttons = {}
@@ -24,6 +22,9 @@ const dragAndDrop = require('./dragAndDrop')
 
 const cancelIconURI = UI.icons.iconBase + 'noun_1180156.svg' // black X
 const checkIconURI = UI.icons.iconBase + 'noun_1180158.svg' // green checkmark; Continue
+
+const ns = UI.ns
+const kb = UI.store
 
 function getStatusArea (context) {
   var box = context.statusArea || context.div || null
@@ -221,15 +222,29 @@ buttons.findImageByClass = function findImageByClass (x) {
   return iconDir + 'noun_10636_grey.svg' // Grey Circle -  some thing
 }
 
+buttons.findImage = (thing) => {
+  const iconDir = UI.icons.iconBase
+  if (thing.sameTerm(ns.foaf('Agent')) || thing.sameTerm(ns.rdf('Resource'))) {
+    return iconDir + 'noun_98053.svg' // Globe
+  }
+  const image = kb.any(thing, ns.sioc('avatar')) ||
+    kb.any(thing, ns.foaf('img')) ||
+    kb.any(thing, ns.vcard('logo')) ||
+    kb.any(thing, ns.vcard('hasPhoto')) ||
+    kb.any(thing, ns.vcard('photo')) ||
+    kb.any(thing, ns.foaf('depiction'))
+  return image ? image.uri : null
+}
+
 // @@ Also add icons for *properties* like  home, work, email, range, domain, comment,
 
 buttons.setImage = function (element, profile) {
   const kb = UI.store
-  const uri = findProfileImage(profile)
+  const uri = buttons.findImage(profile)
   element.setAttribute('src', uri || buttons.findImageByClass(profile))
   if (!uri && profile.uri) {
     kb.fetcher.nowOrWhenFetched(profile.doc(), undefined, () => {
-      element.setAttribute('src', findProfileImage(profile) || buttons.findImageByClass(profile))
+      element.setAttribute('src', buttons.findImage(profile) || buttons.findImageByClass(profile))
     })
   }
 }


### PR DESCRIPTION
findImage used to be a private function in UI.widgets.buttons.setImage, but the logic can be reused other places, so I've tried to extract the logic so that it becomes a method exposed as UI.authn.findProfileImage.

Partially fixes https://github.com/solid/solid-panes/issues/169