### PR TITLE
Do not add an "Add" button when modifying

### DIFF
--- a/src/acl-control.js
+++ b/src/acl-control.js
@@ -526,7 +526,7 @@ UI.aclControl.ACLControlBox5 = function (subject, dom, noun, kb, callback) {
       } // if
     } // for
 
-    if (options.modify) {
+    if (options.modify && !options.doingDefaults) {
       renderAddToolBar(box, lastRow)
     }
 


### PR DESCRIPTION
I really have no idea why these lines of code are there, but given
that they were introduced in a commit that said it was "basically"
working (2e63674702f6c08cef57e771c06f87dbe0a1a0c8), I hope @timbl  can
clarify that.

Since we haven't set up test tooling in solid-ui yet, this PR does not include tests.

Fixes #121.