### PR TITLE
Show what happens when unit API breaks

### DIFF
--- a/src/widgets/peoplePicker.js
+++ b/src/widgets/peoplePicker.js
@@ -105,7 +105,7 @@ export class PeoplePicker {
     return this
   }
 
-  findAddressBook (typeIndex) {
+  findAddressBookOops (typeIndex) {
     return new Promise((resolve, reject) => {
       kb.fetcher.nowOrWhenFetched(typeIndex, (ok, err) => {
         if (!ok) {


### PR DESCRIPTION
@megoth see https://github.com/solid/solid-ui/pull/214#discussion_r383173729 -
you said "Do not need tests that check that an imported function exists - TypeScript does this for us."
But this is an export and not an import, right? Or am I looking in the wrong place?