### PR TITLE
Split out and clean up mostSpecificClassURI, fieldFunction

### DIFF
--- a/src/widgets/forms/fieldFunction.ts
+++ b/src/widgets/forms/fieldFunction.ts
@@ -1,0 +1,51 @@
+import { Node } from 'rdflib'
+import store from '../../store'
+import { debug } from '../../log'
+import { errorMessageBlock } from '../error'
+
+export const field: { [classUri: string]: FieldFunction } = {} // Form field functions by URI of field type.
+
+export type FieldFunction = (
+  dom: HTMLDocument,
+  container: HTMLElement | undefined,
+  already: { },
+  subject: Node,
+  form: Node,
+  doc: Node,
+  callbackFunction: (ok: boolean, errorMessage: string) => void
+) => HTMLElement
+
+/**
+ * Which class of field is this?
+ *
+ * @param x a field
+ * @returns the URI of the most specific class
+ */
+export function mostSpecificClassURI (x: Node): string {
+  const kb = store
+  const ft = kb.findTypeURIs(x)
+  const bot = kb.bottomTypeURIs(ft) // most specific
+  const bots: any[] = []
+  for (const b in bot) bots.push(b)
+  // if (bots.length > 1) throw "Didn't expect "+x+" to have multiple bottom types: "+bots
+  return bots[0]
+}
+
+export function fieldFunction (dom: HTMLDocument, fieldInQuestion: Node): FieldFunction {
+  const uri = mostSpecificClassURI(fieldInQuestion) // What type
+  // const uri = field.uri
+  const fun = field[uri]
+
+  debug(
+    'paneUtils: Going to implement field ' + fieldInQuestion + ' of type ' + uri
+  )
+  if (!fun) {
+    return function () {
+      return errorMessageBlock(
+        dom,
+        'No handler for field ' + fieldInQuestion + ' of type ' + uri
+      )
+    }
+  }
+  return fun
+}

--- a/src/widgets/forms/fieldFunction.ts
+++ b/src/widgets/forms/fieldFunction.ts
@@ -16,10 +16,12 @@ export type FieldFunction = (
 ) => HTMLElement
 
 /**
- * Which class of field is this?
+ * Which class of field is this? Relies on http://www.w3.org/2000/01/rdf-schema#subClassOf and
+ * https://linkeddata.github.io/rdflib.js/doc/classes/formula.html#bottomtypeuris
+ * to find the most specific RDF type if there are multiple.
  *
- * @param x a field
- * @returns the URI of the most specific class
+ * @param x a form field, e.g. `namedNode('https://timbl.com/timbl/Public/Test/Forms/individualForm.ttl#fullNameField')`
+ * @returns the URI of the most specific known class, e.g. `http://www.w3.org/ns/ui#SingleLineTextField`
  */
 export function mostSpecificClassURI (x: Node): string {
   const kb = store

--- a/test/unit/tabs.test.ts
+++ b/test/unit/tabs.test.ts
@@ -42,7 +42,7 @@ describe('tabWidget', () => {
       })
     })
 
-    afterAll(() => clearStore())
+    afterAll(clearStore)
 
     it('creates an element', () => {
       expect(tabWidgetElement.tagName).toEqual('DIV')
@@ -147,7 +147,7 @@ describe('tabWidget', () => {
   })
 
   describe('option ordered', () => {
-    afterAll(() => clearStore())
+    afterAll(clearStore)
 
     it('allows for tabs to be fetched from triples instead of a collection', () => {
       const predicate = meeting('toolList')

--- a/test/unit/widgets/buttons.test.ts
+++ b/test/unit/widgets/buttons.test.ts
@@ -183,7 +183,7 @@ describe('findImage', () => {
   const subject = sym('https://domain.tld/#test')
   const imageObject = sym('https://domain.tld/#image')
 
-  afterEach(() => clearStore())
+  afterEach(clearStore)
 
   it('exists', () => {
     expect(findImage).toBeInstanceOf(Function)

--- a/test/unit/widgets/forms/__snapshots__/fieldFunction.test.ts.snap
+++ b/test/unit/widgets/forms/__snapshots__/fieldFunction.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fieldFunction returns an error block if no matching function exists 1`] = `<div />`;
+
+exports[`fieldFunction returns an error block if subject type undefined 1`] = `
+<div
+  style="margin: 0.1em; padding: 0.5em; border: 0.05em solid gray; background-color: #fee; color:black;"
+>
+  No handler for field &lt;http://example.com/#doesnt-exist&gt; of type undefined
+</div>
+`;

--- a/test/unit/widgets/forms/__snapshots__/fieldFunction.test.ts.snap
+++ b/test/unit/widgets/forms/__snapshots__/fieldFunction.test.ts.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fieldFunction returns an error block if no matching function exists 1`] = `<div />`;
+exports[`fieldFunction returns an error block if no matching function exists 1`] = `
+<div
+  style="margin: 0.1em; padding: 0.5em; border: 0.05em solid gray; background-color: #fee; color:black;"
+>
+  No handler for field &lt;http://example.com/#form&gt; of type http://example.com/#unknown-type
+</div>
+`;
 
 exports[`fieldFunction returns an error block if subject type undefined 1`] = `
 <div

--- a/test/unit/widgets/forms/fieldFunction.test.ts
+++ b/test/unit/widgets/forms/fieldFunction.test.ts
@@ -9,9 +9,7 @@ import {
 } from '../../../../src/widgets/forms/fieldFunction'
 import { clearStore } from '../../helpers/clearStore'
 
-afterEach(() => {
-  clearStore()
-})
+afterEach(clearStore)
 
 describe('mostSpecificClassURI', () => {
   it('exists', () => {

--- a/test/unit/widgets/forms/fieldFunction.test.ts
+++ b/test/unit/widgets/forms/fieldFunction.test.ts
@@ -7,15 +7,27 @@ import {
   fieldFunction,
   mostSpecificClassURI
 } from '../../../../src/widgets/forms/fieldFunction'
+import { clearStore } from '../../helpers/clearStore'
+
+afterEach(() => {
+  clearStore()
+})
 
 describe('mostSpecificClassURI', () => {
   it('exists', () => {
     expect(mostSpecificClassURI).toBeInstanceOf(Function)
   })
-  it('runs', () => {
+  it('reports the RDF type if there is only one', () => {
     const form = namedNode('http://example.com/#form')
     uiStore.add(form, ns.rdf('type'), namedNode('http://example.com/#type'), namedNode('http://example.com/'))
     expect(mostSpecificClassURI(form)).toEqual('http://example.com/#type')
+  })
+  it('reports the subtype if there are one super and one sub type', () => {
+    const node = namedNode('http://example.com/#form')
+    uiStore.add(node, ns.rdf('type'), namedNode('http://example.com/#human'), namedNode('http://example.com/'))
+    uiStore.add(node, ns.rdf('type'), namedNode('http://example.com/#employee'), namedNode('http://example.com/'))
+    uiStore.add(namedNode('http://example.com/#employee'), ns.rdfs('subClassOf'), namedNode('http://example.com/#human'), namedNode('http://example.com/'))
+    expect(mostSpecificClassURI(node)).toEqual('http://example.com/#employee')
   })
 })
 

--- a/test/unit/widgets/forms/fieldFunction.test.ts
+++ b/test/unit/widgets/forms/fieldFunction.test.ts
@@ -1,0 +1,60 @@
+import { namedNode } from 'rdflib'
+import ns from '../../../../src/ns'
+import uiStore from '../../../../src/store'
+
+import {
+  field,
+  fieldFunction,
+  mostSpecificClassURI
+} from '../../../../src/widgets/forms/fieldFunction'
+
+describe('mostSpecificClassURI', () => {
+  it('exists', () => {
+    expect(mostSpecificClassURI).toBeInstanceOf(Function)
+  })
+  it('runs', () => {
+    const form = namedNode('http://example.com/#form')
+    uiStore.add(form, ns.rdf('type'), namedNode('http://example.com/#type'), namedNode('http://example.com/'))
+    expect(mostSpecificClassURI(form)).toEqual('http://example.com/#type')
+  })
+})
+
+describe('fieldFunction', () => {
+  it('exists', () => {
+    expect(fieldFunction).toBeInstanceOf(Object)
+  })
+  it('returns the field function if it exists', () => {
+    // create a function for type http://example.com/#type
+    const myFunction = () => document.createElement('div')
+    field['http://example.com/#type'] = myFunction
+
+    // create a field of type http://example.com/#type
+    const form = namedNode('http://example.com/#form')
+    uiStore.add(form, ns.rdf('type'), namedNode('http://example.com/#type'), namedNode('http://example.com/'))
+
+    expect(fieldFunction(document, namedNode('http://example.com/#form'))).toEqual(myFunction)
+  })
+
+  it('returns an error block if subject type undefined', () => {
+    const fn = fieldFunction(document, namedNode('http://example.com/#doesnt-exist'))
+    const result = fn(document, document.createElement('div'), {},
+      namedNode('http://example.com/#subject'),
+      namedNode('http://example.com/#form'),
+      namedNode('http://example.com/'),
+      () => {})
+    expect(result).toMatchSnapshot()
+  })
+
+  it('returns an error block if no matching function exists', () => {
+    // create a field of type http://example.com/#unknown-type
+    const form = namedNode('http://example.com/#form')
+    uiStore.add(form, ns.rdf('type'), namedNode('http://example.com/#unknown-type'), namedNode('http://example.com/'))
+    const fn = fieldFunction(document, namedNode('http://example.com/#form'))
+    const result = fn(document, document.createElement('div'), {},
+      namedNode('http://example.com/#subject'),
+      namedNode('http://example.com/#form'),
+      namedNode('http://example.com/'),
+      () => {})
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/test/unit/widgets/forms/index.test.ts
+++ b/test/unit/widgets/forms/index.test.ts
@@ -7,7 +7,6 @@ import {
   buildCheckboxForm,
   editFormButton,
   field,
-  fieldFunction,
   fieldLabel,
   fieldStore,
   findClosest,
@@ -16,7 +15,6 @@ import {
   makeSelectForCategory,
   makeSelectForNestedCategory,
   makeSelectForOptions,
-  mostSpecificClassURI,
   newButton,
   newThing,
   promptForNew,
@@ -1087,26 +1085,6 @@ describe('Comment', () => {
   </undefined>
 </div>
 `)
-  })
-})
-
-describe('mostSpecificClassURI', () => {
-  it('exists', () => {
-    expect(mostSpecificClassURI).toBeInstanceOf(Function)
-  })
-  it('runs', () => {
-    const form = namedNode('http://example.com/#form')
-    uiStore.add(form, ns.rdf('type'), namedNode('http://example.com/#type'), namedNode('http://example.com/'))
-    expect(mostSpecificClassURI(form)).toEqual('http://example.com/#type')
-  })
-})
-
-describe('fieldFunction', () => {
-  it('exists', () => {
-    expect(fieldFunction).toBeInstanceOf(Object)
-  })
-  it('runs', () => {
-    expect(fieldFunction(document, namedNode('http://example.com/#this'))).toBeInstanceOf(Function)
   })
 })
 


### PR DESCRIPTION
100% branch coverage, move-to-TS, examples, and typedoc for both functions.

Also simplified the other occurrences of `() => { clearStore() }` to just `clearStore`.