### PR TITLE
Fixing jest config + Ignoring debug methods for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  verbose: true,
+  setupFilesAfterEnv: [
+    './test/setup.ts'
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  verbose: true,
-  setupFilesAfterEnv: [
-    './test/setup.ts'
-  ]
+  verbose: true
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,0 @@
-module.exports = {
-  verbose: true,
-  coveragePathIgnorePatterns: ['src/test/*.js']
-}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,7 @@
+// We don't want to output debug messages to console as part of the tests
+jest.mock('../src/debug')
+const debug = require('../src/debug')
+debug.log.mockImplementation(() => null)
+debug.warn.mockImplementation(() => null)
+debug.error.mockImplementation(() => null)
+debug.trace.mockImplementation(() => null)

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,0 @@
-// We don't want to output debug messages to console as part of the tests
-jest.mock('../src/debug')
-const debug = require('../src/debug')
-debug.log.mockImplementation(() => null)
-debug.warn.mockImplementation(() => null)
-debug.error.mockImplementation(() => null)
-debug.trace.mockImplementation(() => null)


### PR DESCRIPTION
Realized that jest config must have file-extension .js in order to let jest recognize it properly. Cleaned it up a bit and made it so that calls on debug methods are ignored in tests.