### PR TITLE
Build types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
     "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
+
     "outDir": "lib" /* Redirect output structure to the directory. */,
+    "rootDir": "src/",
+
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "incremental": true,                   /* Enable incremental compilation */
@@ -67,8 +70,6 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "include": [
-    "src/**/*",
-    "test/**/*",
-    "__mocks__/*"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
We wanted to get it to build types for `src/`, `test/` and `__mocks__/`, but we also wanted the output to go to lib/index.d.ts and not lib/src/index.d.ts. We got the types to build to lib/index.d.ts but now it only builds `src/`. If someone knows how to make it check the types of `test/` and `__mocks__/` as well, please contribute! :)