### PR TITLE
publish version to npm on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
 
-  npm:
+  npm-publish-build:
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -69,3 +69,19 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ env.GITHUB_REF_SLUG }}
+  npm-publish-latest:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          dry-run: true
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,5 @@ jobs:
           node-version: 14.x
       - uses: JS-DevTools/npm-publish@v1
         with:
-          dry-run: true
           token: ${{ secrets.NPM_TOKEN }}
           tag: latest


### PR DESCRIPTION
With this change, solid-ui will be automatically published to npm when a version is commited/merged to the main branch.

The other job, that I renamed to npm-publish-build, was already present and published everything to npm using the git slug. With this change we also publish a version without slug as latest npm package, but only when on main branch