### PR TITLE
Sharing-pane : setting a specific sharing for file should return default acl from parent

### DIFF
--- a/src/acl/access-controller.ts
+++ b/src/acl/access-controller.ts
@@ -43,13 +43,13 @@ export class AccessController {
     if (defaultHolder && defaultACLDoc) {
       this.isUsingDefaults = true
       const aclDefaultStore = adoptACLDefault(this.targetDoc, targetACLDoc, defaultHolder, defaultACLDoc)
-      this.mainCombo = new AccessGroups(targetDoc, targetACLDoc, this, aclDefaultStore, { defaults: true })
+      this.mainCombo = new AccessGroups(targetDoc, targetACLDoc, this, aclDefaultStore, { defaults: this.isContainer })
       this.defaultsCombo = null
       this.defaultsDiffer = false
     } else {
       this.isUsingDefaults = false
       this.mainCombo = new AccessGroups(targetDoc, targetACLDoc, this, store)
-      this.defaultsCombo = new AccessGroups(targetDoc, targetACLDoc, this, store, { defaults: true })
+      this.defaultsCombo = new AccessGroups(targetDoc, targetACLDoc, this, store, { defaults: this.isContainer })
       this.defaultsDiffer = !sameACL(this.mainCombo.aclMap, this.defaultsCombo.aclMap)
     }
   }
@@ -76,7 +76,7 @@ export class AccessController {
     if (this.defaultsCombo && this.defaultsDiffer) {
       this.rootElement.appendChild(this.renderRemoveDefaultsController())
       this.rootElement.appendChild(this.defaultsCombo.render())
-    } else if (this.isEditable) {
+    } else if (this.isEditable && this.isContainer) {
       this.rootElement.appendChild(this.renderAddDefaultsController())
     }
     if (!this.targetIsProtected && this.isUsingDefaults) {

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -231,6 +231,8 @@ export function makeACLGraphbyCombo (
 ): void {
   const ACL = ns.acl
   for (const combo in byCombo) {
+    const pairs = byCombo[combo]
+    if (!pairs.length) continue // do not add to store when no agent
     const modeURIs = combo.split('\n')
     let short = modeURIs
       .map(function (u) {
@@ -249,7 +251,6 @@ export function makeACLGraphbyCombo (
     for (let i = 0; i < modeURIs.length; i++) {
       kb.add(a, ACL('mode'), kb.sym(modeURIs[i]), aclDoc)
     }
-    const pairs = byCombo[combo]
     for (let i = 0; i < pairs.length; i++) {
       const pred = pairs[i][0]
       const ag = pairs[i][1]


### PR DESCRIPTION
@timbl 
Sharing-pane : setting a specific sharing for file returns a void content, but should return the parent acl without acl:default

This PR resolves the following issue #396 and issue https://github.com/solid/solidcommunity.net/issues/39 : 
I did not succeed to make a test

1. the sharing-pane for file: 
- did not display any default content when clicking on `Set specific sharing` (it is looking for a folder acl with acl:default)
- and should not display the button `Set the sharing of folder contents separately from the sharing for the folder`
2. when adding any type of agent the acl was created with only an acl:Read and user was locked out from the file
