### PR TITLE
Restore the last used IDP

### DIFF
--- a/src/authn/authn.ts
+++ b/src/authn/authn.ts
@@ -1023,6 +1023,7 @@ export function renderSignInPopup (dom: HTMLDocument) {
   issuerTextInput.setAttribute('type', 'text')
   issuerTextInput.setAttribute('style', 'margin-left: 0 !important; flex: 1; margin-right: 5px !important')
   issuerTextInput.setAttribute('placeholder', 'https://example.com')
+  issuerTextInput.value = localStorage.getItem('loginIssuer') || ''
   const issuerTextGoButton = dom.createElement('button')
   issuerTextGoButton.innerText = 'Go'
   issuerTextGoButton.setAttribute('style', 'margin-top: 12px; margin-bottom: 12px;')


### PR DESCRIPTION
This PR prefills the text field with the last used IDP (already stored in `localStorage`):

<img width="486" alt="image" src="https://user-images.githubusercontent.com/675313/139944258-7f28396f-7e1c-4131-9654-f49b8276c8df.png">
